### PR TITLE
import BinaryQuadraticModel

### DIFF
--- a/dimod/serialization/json.py
+++ b/dimod/serialization/json.py
@@ -41,6 +41,7 @@ import numpy as np
 from dimod import __version__
 from dimod.sampleset import SampleSet
 from dimod.vartypes import Vartype
+from dimod import BinaryQuadraticModel
 
 __all__ = 'DimodEncoder', 'DimodDecoder', 'dimod_object_hook'
 


### PR DESCRIPTION
loading from json is currently failing with

```
bqm = coo.load(open(s), vartype=dimod.BINARY)
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/tmp/ipykernel_31901/580148923.py in <module>
      1 s = '/home/daniel/Downloads/bqm_cmi_german-credit_k14.json'
----> 2 bqm = json.loads(open(s).read(), cls=DimodDecoder)
      3 
      4 #s = '/home/daniel/hss-overview-benchmarks/qubos/g000283.qubo'
      5 #s = '/home/daniel/hss-overview-benchmarks/qubos/g001327.qubo'

~/anaconda3/lib/python3.8/json/__init__.py in loads(s, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
    368     if parse_constant is not None:
    369         kw['parse_constant'] = parse_constant
--> 370     return cls(**kw).decode(s)

~/anaconda3/lib/python3.8/json/decoder.py in decode(self, s, _w)
    335 
    336         """
--> 337         obj, end = self.raw_decode(s, idx=_w(s, 0).end())
    338         end = _w(s, end).end()
    339         if end != len(s):

~/anaconda3/lib/python3.8/json/decoder.py in raw_decode(self, s, idx)
    351         """
    352         try:
--> 353             obj, end = self.scan_once(s, idx)
    354         except StopIteration as err:
    355             raise JSONDecodeError("Expecting value", s, err.value) from None

~/anaconda3/lib/python3.8/site-packages/dimod/serialization/json.py in dimod_object_hook(obj)
     82         # in the future we could handle subtypes but right now we just have the
     83         # one
---> 84         return BinaryQuadraticModel.from_serializable(obj)
     85     return obj
     86 

NameError: name 'BinaryQuadraticModel' is not defined
```
